### PR TITLE
Fixes to support Quasar 2

### DIFF
--- a/app-extension/src/boot/register.js
+++ b/app-extension/src/boot/register.js
@@ -1,5 +1,7 @@
-import Vue from 'vue'
+import { boot } from 'quasar/wrappers'
 import VuePlugin from '@quasar/quasar-ui-qmarkdown/src/index.js'
 import '@quasar/quasar-ui-qmarkdown/dist/index.css'
 
-Vue.use(VuePlugin)
+export default boot(({ app }) => {
+  app.use(VuePlugin)
+})

--- a/ui/src/QMarkdown.js
+++ b/ui/src/QMarkdown.js
@@ -14,7 +14,7 @@ export default {
   QMarkdown,
   getTagParts,
 
-  install (Vue) {
-    Vue.component(QMarkdown.name, QMarkdown)
+  install (app) {
+    app.component(QMarkdown.name, QMarkdown)
   }
 }

--- a/ui/src/components/QMarkdown.js
+++ b/ui/src/components/QMarkdown.js
@@ -408,7 +408,7 @@ export default defineComponent({
 
         // get the markdown - slot overrides 'src'
         let markdown = source.value
-        if (slots.defaults !== undefined && slots.default()[ 0 ].children.trim().length > 0) {
+        if (slots.default !== undefined && slots.default()[ 0 ].children.trim().length > 0) {
           markdown = slots.default()[ 0 ].children.replace(/\\ /g, '\n').replace(/'/g, '')
         }
 

--- a/ui/src/components/QMarkdown.js
+++ b/ui/src/components/QMarkdown.js
@@ -369,7 +369,7 @@ export default defineComponent({
 
     function __copyMarkdownToClipboard () {
       let markdown = source.value
-      if (slots.default()[ 0 ].children.trim().length > 0) {
+      if (slots.default !== undefined && slots.default()[ 0 ].children.trim().length > 0) {
         markdown = slots.default()[ 0 ].children
       }
 
@@ -408,7 +408,7 @@ export default defineComponent({
 
         // get the markdown - slot overrides 'src'
         let markdown = source.value
-        if (slots.default()[ 0 ].children.trim().length > 0) {
+        if (slots.defaults !== undefined && slots.default()[ 0 ].children.trim().length > 0) {
           markdown = slots.default()[ 0 ].children.replace(/\\ /g, '\n').replace(/'/g, '')
         }
 

--- a/ui/src/index.js
+++ b/ui/src/index.js
@@ -14,7 +14,7 @@ export default {
   QMarkdown,
   getTagParts,
 
-  install (Vue) {
-    Vue.component(QMarkdown.name, QMarkdown)
+  install (app) {
+    app.component(QMarkdown.name, QMarkdown)
   }
 }


### PR DESCRIPTION
This merge request updates the component to work with Quasar 2:

- convert Vue.use and Vue.component to app.use and app.component in boot file
- fix rendering when there is no default slot, e.g. when src property is provided