### PR TITLE
Protect from errors in markdown-it

### DIFF
--- a/ui/src/components/QMarkdown.js
+++ b/ui/src/components/QMarkdown.js
@@ -407,7 +407,7 @@ export default defineComponent({
         const tocData = []
 
         // get the markdown - slot overrides 'src'
-        let markdown = source.value
+        let markdown = source.value || ''
         if (slots.default !== undefined && slots.default()[ 0 ].children.trim().length > 0) {
           markdown = slots.default()[ 0 ].children.replace(/\\ /g, '\n').replace(/'/g, '')
         }


### PR DESCRIPTION
When passing a value from `source.value` it's possible that a value may be null. Double check and use an empty string in these cases.