### PR TITLE
add option loading for markdown-it plugins

### DIFF
--- a/ui/src/components/QMarkdown.js
+++ b/ui/src/components/QMarkdown.js
@@ -323,7 +323,13 @@ export default defineComponent({
 
         if (allProps.value.plugins.length > 0) {
           allProps.value.plugins.forEach(plugin => {
-            md.use(plugin)
+            if (plugin instanceof Function) {
+              md.use(plugin)
+            } else {
+              if (plugin.plugin instanceof Function && plugin.options) {
+                md.use(plugin.plugin, plugin.options)
+              }
+            }
           })
         }
 


### PR DESCRIPTION
change array of markdown-it plugins.
if plugin is type function then markdown load plugin without options.
if plugin is type of object({plugin: <markdown-it plugin>, options: <options object>}) then markdown load plugin with options.