### PR TITLE
fix(types): fix MarkdownIt type exports

### DIFF
--- a/ui/types/types.d.ts
+++ b/ui/types/types.d.ts
@@ -1,4 +1,4 @@
-import { MarkdownIt } from "@types/markdown-it";
+import MarkdownIt from "markdown-it";
 export * from "./vue-prop-types";
 
 export interface TocDefinition {
@@ -9,5 +9,6 @@ export interface TocDefinition {
   };
 export type TocDefinitionArray = TocDefinition[];
 
-export interface MarkdownItPlugin = MarkdownIt.PluginSimple | MarkdownIt.PluginWithOptions | MarkdownIt.PluginWithParams;
+export type MarkdownItPlugin = 
+  MarkdownIt.PluginSimple | MarkdownIt.PluginWithOptions | MarkdownIt.PluginWithParams;
 export type MarkdownItPluginsArray = MarkdownItPlugin[];


### PR DESCRIPTION
Typescript complained about the `export interface MarkdownItPlugin =` syntax and the `MarkdownIt` import.