### PR TITLE
fix: ssr treats all anchor links as external

### DIFF
--- a/ui/src/util/extendLink.js
+++ b/ui/src/util/extendLink.js
@@ -19,6 +19,7 @@ export default function extendLink (md, { noopener = true, noreferrer = true }) 
       }
     }
     else if (token.attrs[ hrefIndex ][ 1 ][ 0 ] === '/'
+      || token.attrs[ hrefIndex ][ 1 ][ 0 ] === '#'
       || token.attrs[ hrefIndex ][ 1 ].startsWith('..')) {
       token.attrSet('class', 'q-markdown--link q-markdown--link-local')
     }


### PR DESCRIPTION
https://github.com/quasarframework/quasar-ui-qmarkdown/commit/556ff29af89b57aa58b74525506476fb405ddd6f made it skip the anchor expanding when we're in SSR mode. However, that means that a later check will mark it as an external link (which adds the external-link icon)

This resolves the difference between the SSG (and probably SSR) and the browsers rendering